### PR TITLE
Update indirect-fire-support.mdx

### DIFF
--- a/src/content/sop/communications/indirect-fire-support.mdx
+++ b/src/content/sop/communications/indirect-fire-support.mdx
@@ -8,7 +8,7 @@ import { Callout } from "nextra/components";
 
 # Indirect Fire Support and CAS
 SPECTRE uses a simplified but effective “5-Line Briefing” call for Fire Support and Close Air Support.
-Whenever an Aircraft or Indirect Fire Support team receives a Line Brief from an JTAC (Observer), they must use [close loop communications](/sop/communications/radio-communications#closed-loop-communications) and repeat back the same line that the observer called. This is to minimize BLUE ON BLUE incidents and ensure that Fire is properly delivered to the enemy. 
+Whenever an Aircraft or Indirect Fire Support team receives a Line Brief from a JTAC (Observer), they must use [close loop communications](/sop/communications/radio-communications#closed-loop-communications) and repeat back the same line that the observer called. This is to minimize BLUE ON BLUE incidents and ensure that Fire is properly delivered to the enemy. 
 
 To effectively call in a fire mission either by IDF or CAS, the following procedures should be used:
 
@@ -18,7 +18,7 @@ To effectively call in a fire mission either by IDF or CAS, the following proced
 
 2. **Aircraft or Mortar Team callsign acknowledges the call**:
 
-`[Observer or JTAC callsign] this is [Aircraft or Mortar Team callsign], good copy, over.`
+`[JTAC callsign] this is [Aircraft or Mortar Team callsign], good copy, over.`
 
 3. **JTAC provides friendly unit's location / mark**:
 


### PR DESCRIPTION
an to a? not sure if that's correct

and deleted only time 'Observer' was used next to JTAC callsign in your example.